### PR TITLE
Update fly_simulator.launch

### DIFF
--- a/decision/state_machine/launch/fly_simulator.launch
+++ b/decision/state_machine/launch/fly_simulator.launch
@@ -14,7 +14,7 @@
   <arg name="init_y" value="-21.0"/>
   <arg name="init_z" value="0.0"/> 
 
-  <arg name="forest" value="0"/> 
+  <arg name="forest" value="1"/> 
 
   <!-- map generation -->
   <node pkg="map_generator" name="random_forest" type="random_forest" output="screen" if="$(arg forest)">    


### PR DESCRIPTION
arg `forest` must be turned ON, otherwise it will look for the 'mockamap' package which is not included, and if cloning the 'mockamap' repository then there is no 'fly_map.launch' file anyway